### PR TITLE
Added basic multi-monitor support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This project provides a set of scripts to find, unpack, and display wallpapers f
 -   **Python 3**
 -   **jq:** A command-line JSON processor.
 -   **mpvpaper:** For video wallpapers.
--   **GTK4, gtk4-layer-shell, WebKitGTK & PyGObject:** For web wallpapers.
+-   **GTK4, WebKitGTK & PyGObject:** For web wallpapers.
 
 ## Installation
 
@@ -43,7 +43,7 @@ This project provides a set of scripts to find, unpack, and display wallpapers f
 
 2.  **Install dependencies (for Arch Linux):**
     ```bash
-    yay -S jq mpvpaper gtk4 webkitgtk-6.0 python-gobject gtk4-layer-shell
+    yay -S jq mpvpaper gtk4 webkitgtk-6.0 python-gobject
     ```
 
 3.  **Make the main script executable:**

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+if [ -z "$1" ]; then
+	echo "Usage: start.sh <wallpaper_id>"
+	echo "start a wallpaper on all monitors"
+	exit 1
+fi
+wallid="$1"
+/home/buddy/manbuild/HyprPaper-we/hyprpaper-we.sh stopall
+monitors="$(hyprctl monitors | grep ID | cut -c 9- | rev | cut -c 9- | rev)"
+for monitor in $monitors; do
+	/home/buddy/manbuild/HyprPaper-we/hyprpaper-we.sh "$wallid" $monitor &
+done
+sleep 3
+eww reload
+exit 0

--- a/web_viewer.py
+++ b/web_viewer.py
@@ -1,5 +1,4 @@
-zimport gi
-
+import gi
 
 
 gi.require_version('Gtk', '4.0')
@@ -135,4 +134,3 @@ if __name__ == "__main__":
 
 
     app.run(None)
-


### PR DESCRIPTION
add the ability to stop all running instances(atleast video wise, haven't tested with web yet) with a single command adds start.sh, which starts the same provided wallpaper on each monitor 
updated read me accordingly
has worked for me so far
also adjusted to make modifying mpv options a bit easier, current ones limit fps to 20 as it helped with performance across 3 monitors, and Imo doesn't look to bad
a default monitor must be manually specified in the main script, but the variable is near the top so it should hopefully be a non-issue