### PR TITLE
Added support for newer versions of hyprland

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,18 @@ This project provides a set of scripts to find, unpack, and display wallpapers f
 
 4.  **Configure Hyprland:**
     Add the following window rules to your `~/.config/hypr/hyprland.conf` file. This is crucial for web wallpapers to appear correctly in the background.
-
+    
+    Since hyprland v0.4+ windowrulev2 is depracated and the following should be used:
+    ```
+    windowrule {
+        match = class:^(HyprPaper-WE-Window)$
+        workspace = special silent
+        nofocus = true
+        noanim = true
+        rounding = 0
+    }
+    ``` 
+    For versions older than v0.4+ where windowrulev2 is supported use:
     ```
     # Rules for HyprPaper-WE
     windowrulev2 = workspace special silent, class:^(HyprPaper-WE-Window)$

--- a/README.md
+++ b/README.md
@@ -57,10 +57,11 @@ This project provides a set of scripts to find, unpack, and display wallpapers f
     Since hyprland v0.4+ windowrulev2 is depracated and the following should be used:
     ```
     windowrule {
-        match = class:^(HyprPaper-WE-Window)$
+        name = hyprpaper-we-rules
+        match:class = ^(HyprPaper-WE-Window)$
         workspace = special silent
-        nofocus = true
-        noanim = true
+        no_focus = true
+        no_anim = true
         rounding = 0
     }
     ``` 


### PR DESCRIPTION
As of v0.4 windowrulev2 is deprecated and windowrule clauses are recommended. Updated readme.md to include support for newer versions.